### PR TITLE
Update renovate config

### DIFF
--- a/CustomizeCommand.php
+++ b/CustomizeCommand.php
@@ -297,7 +297,7 @@ class CustomizeCommand extends BaseCommand {
     }
 
     $message = $messages[$name];
-    $message = is_array($message) ? implode("\n", $message) : $message;
+    $message = is_array($message) ? implode("\n", array_filter(array_map(fn($v): string => is_scalar($v) ? (string) $v : '', $message))) : $message;
 
     $tokens += ['{{ cwd }}' => $this->cwd];
     // Only support top-level composer.json entries as tokens for now.

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,20 @@
 {
     "extends": ["config:recommended"],
     "automerge": true,
-    "dependencyDashboard": true
+    "rangeStrategy": "bump",
+    "dependencyDashboard": true,
+    "pinDigests": true,
+    "branchPrefix": "deps/",
+    "packageRules": [
+        {
+            "matchManagers": ["composer"],
+            "matchUpdateTypes": ["major"],
+            "enabled": false
+        },
+        {
+            "matchPackageNames": ["*"],
+            "groupName": "all dependencies",
+            "groupSlug": "all"
+        }
+    ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,26 +1,11 @@
 {
     "extends": ["config:recommended"],
     "automerge": true,
-    "rangeStrategy": "bump",
     "dependencyDashboard": true,
     "pinDigests": true,
     "branchPrefix": "deps/",
+    "enabledManagers": ["github-actions"],
     "packageRules": [
-        {
-            "matchDepNames": ["php"],
-            "matchManagers": ["composer"],
-            "enabled": false
-        },
-        {
-            "matchDepNames": ["node", "yarn"],
-            "matchManagers": ["npm"],
-            "enabled": false
-        },
-        {
-            "matchManagers": ["npm", "composer"],
-            "matchUpdateTypes": ["major"],
-            "enabled": false
-        },
         {
             "matchPackageNames": ["*"],
             "groupName": "all dependencies",

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,17 @@
     "branchPrefix": "deps/",
     "packageRules": [
         {
+            "matchDepNames": ["php"],
             "matchManagers": ["composer"],
+            "enabled": false
+        },
+        {
+            "matchDepNames": ["node", "yarn"],
+            "matchManagers": ["npm"],
+            "enabled": false
+        },
+        {
+            "matchManagers": ["npm", "composer"],
             "matchUpdateTypes": ["major"],
             "enabled": false
         },

--- a/tests/phpunit/Functional/CustomizerTestCase.php
+++ b/tests/phpunit/Functional/CustomizerTestCase.php
@@ -704,7 +704,7 @@ abstract class CustomizerTestCase extends TestCase {
 
     // Compare files where content is not ignored.
     foreach ($dir1_files as $file => $hash) {
-      if (isset($dir2_files[$file]) && $hash !== $dir2_files[$file] && !in_array($file, $rules['ignore_content'])) {
+      if (isset($dir2_files[$file]) && $hash !== $dir2_files[$file] && !in_array($file, $rules['ignore_content'], TRUE)) {
         $diffs['different_files'][] = $file;
       }
     }


### PR DESCRIPTION
Updated renovate.json with standardised config via repoRanger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Updates `renovate.json` with a standardized Renovate configuration via repoRanger — removes some prior package rules and rangeStrategy, and adds/adjusts several Renovate fields.

## Changes

- renovate.json
  - Removes `rangeStrategy` and several previously-disabled package rules.
  - Adds/updates fields:
    - `pinDigests: true`
    - `branchPrefix: "deps/"`
    - `enabledManagers: ["github-actions"]`
    - `packageRules` simplified to a single grouping rule that groups dependencies under "all dependencies" (groupSlug: "all")
    - Keeps `extends: ["config:recommended"]`, `automerge: true`, and `dependencyDashboard: true`
  - Lines changed: approximately +11/-1

- CustomizeCommand.php
  - When message values are arrays, only scalar elements are kept and joined (non-scalar values filtered out) before concatenation; no change for non-array messages.
  - Lines changed: +1/-1

- tests/phpunit/Functional/CustomizerTestCase.php
  - Tightened `in_array` call to use strict comparison for the ignore-content check in `assertDirectoriesEqual`.
  - Lines changed: +1/-1

## Possibly related

- Possibly related to the repository issue tracker: https://github.com/AlexSkrypnyk/customizer/issues
- Possibly related to Composer issue referenced in tests: https://github.com/composer/composer/issues/12107
<!-- end of auto-generated comment: release notes by coderabbit.ai -->